### PR TITLE
Это изменение фиксит невозможность загрузить во вьювер группу с чем-л…

### DIFF
--- a/src/objects/project-model.ts
+++ b/src/objects/project-model.ts
@@ -7,6 +7,18 @@ import { Group } from "./entities/group";
 import { Mesh } from "./entities/mesh";
 import { DefaultObject } from "./entities/default-object";
 
+function isGroupMeshOnly(grp:THREE.Group):boolean{
+  let result = true;
+  let i=0;
+  while (i<grp.children.length){
+
+    if  (grp.children[i].type!='Mesh'){
+      result=false
+      break
+    }
+  }
+  return result
+}
 // сущность проекта, загружаемая с сервера за один импорт
 export class ProjectModel {
   protected _id: string;
@@ -61,10 +73,17 @@ export class ProjectModel {
 
   public initModel(object: THREE.Object3D): Entity {
     if (object instanceof THREE.Group) {
-      this._unionMesh = new UnionMesh(object, this);
-      this._objects = this._unionMesh.objects;
+      if (isGroupMeshOnly(object)){
+        this._unionMesh = new UnionMesh(object, this);
+        this._objects = this._unionMesh.objects;
 
+      }
+      else {
+        this._objects=[...object.children]
+      }
       return new Group(object, this, undefined);
+
+
     } else if (object instanceof THREE.Mesh) {
       this._objects = [object];
 


### PR DESCRIPTION
### Группы с любой геометрией
Это изменение фиксит невозможность загрузить во вьювер группу с чем-либо кроме мешки.  В одном единственном файле  `src/objects/project-model.ts`\


<details>

<summary>Вот такая вот красота получается</summary>


<img width="512" alt="image" src="https://github.com/contextmachine/cxm-flow-a/assets/92893394/e7c2f0b9-1d02-46c1-9a2e-0121e7d4406e">
</details>